### PR TITLE
Point readme to updated repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 Supplemental material for Kubernetes Training.
 
-```
-kubectl apply -f https://raw.githubusercontent.com/datawire/qotm/master/kubernetes/qotm-deployment.yaml
-kubectl apply -f https://raw.githubusercontent.com/datawire/qotm/master/kubernetes/qotm-service.yaml
-```
+# Archived Repository
+
+This repository is no longer being actively maintained. Please see the [datawire/quote](https://github.com/datawire/quote) repo for 
+an actively maintined re-write of the quote of the moment service written in go.  
+
 
 # License
 


### PR DESCRIPTION
Signed-off-by: AliceProxy <alicewasko@datawire.io

The code in this repository is no longer being used as part of any of the latest tutorials/documentation at https://getambassador.io. The intent of this PR is to add a link to the new datawire/quote repo and a message about the state of this repository before it is archived. 